### PR TITLE
Reworked the engine core architecture and creating a window

### DIFF
--- a/Engine/Source/Engine/Engine.cpp
+++ b/Engine/Source/Engine/Engine.cpp
@@ -6,21 +6,89 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <Core/Platform/Timer.h>
 #include <Engine/Engine.h>
 
 namespace CaveGame
 {
 
+struct EngineData
+{
+    Window window;
+};
+
+static EngineData* s_engine;
+
 bool Engine::initialize()
 {
+    if (s_engine)
+    {
+        // The engine has already been initialized.
+        return false;
+    }
+
+    // Allocate the memory for the engine structure.
+    s_engine = new EngineData();
+
+    if (!s_engine->window.initialize())
+    {
+        // NOTE: If the window creation fails there is no point in continuing the program execution.
+        // Without a window, the game is definetely unplayable.
+        return false;
+    }
+
     return true;
 }
 
 void Engine::shutdown()
-{}
+{
+    if (!s_engine)
+    {
+        // The engine has already been shut down.
+        return;
+    }
 
-void Engine::run()
-{}
+    s_engine->window.shutdown();
+
+    delete s_engine;
+    s_engine = nullptr;
+}
+
+void Engine::run(GameLoop& game_loop)
+{
+    if (!game_loop.on_game_start())
+    {
+        // The game start function requested the application to exit.
+        return;
+    }
+
+    // NOTE: For the first frame assume that the game runs at 60FPS.
+    // Running the update function with a delta time of 0 might cause errors.
+    float last_frame_delta_time = 1.0F / 60.0F;
+
+    while (game_loop.is_running())
+    {
+        Timer frame_timer;
+
+        s_engine->window.process_event_queue();
+        if (s_engine->window.should_close())
+        {
+            game_loop.stop_running();
+            continue;
+        }
+
+        game_loop.on_game_update(last_frame_delta_time);
+        last_frame_delta_time = frame_timer.stop_and_get_elapsed_seconds();
+    }
+
+    game_loop.on_game_end();
+}
+
+Window& Engine::get_window()
+{
+    CAVE_ASSERT(s_engine);
+    return s_engine->window;
+}
 
 bool initialize_core_systems()
 {

--- a/Engine/Source/Engine/Engine.h
+++ b/Engine/Source/Engine/Engine.h
@@ -8,16 +8,34 @@
 
 #pragma once
 
+#include <Core/Platform/Window.h>
+#include <Engine/GameLoop.h>
+
 namespace CaveGame
 {
 
 class Engine
 {
 public:
-    bool initialize();
-    void shutdown();
+    static bool initialize();
+    static void shutdown();
 
-    void run();
+    template<typename GameLoopType>
+    ALWAYS_INLINE static void run()
+    {
+        GameLoopType game_loop_instance = {};
+        run(static_cast<GameLoop&>(game_loop_instance));
+    }
+
+public:
+    //
+    // Returns the pointer to the window instance.
+    // If no window has been created (or has been destroyed) this function will return nullptr.
+    //
+    NODISCARD static Window& get_window();
+
+private:
+    static void run(GameLoop& game_loop);
 };
 
 bool initialize_core_systems();

--- a/Engine/Source/Engine/GameLoop.h
+++ b/Engine/Source/Engine/GameLoop.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Catalin Ionescu 2024. All rights reserved.
+ * Copyright (c) Robert Bengulescu 2024. All rights reserved.
+ * Copyright (c) Traian Avram 2024. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <Core/CoreTypes.h>
+
+namespace CaveGame
+{
+
+class GameLoop
+{
+public:
+    virtual bool on_game_start() { return true; }
+    
+    virtual void on_game_end() {}
+
+    virtual void on_game_update(float delta_time) = 0;
+
+public:
+    NODISCARD ALWAYS_INLINE bool is_running() const { return m_is_running; }
+    ALWAYS_INLINE void stop_running() { m_is_running = false; }
+
+private:
+    bool m_is_running { true };
+};
+
+} // namespace CaveGame

--- a/Source/CaveGameLoop.cpp
+++ b/Source/CaveGameLoop.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Catalin Ionescu 2024. All rights reserved.
+ * Copyright (c) Robert Bengulescu 2024. All rights reserved.
+ * Copyright (c) Traian Avram 2024. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <CaveGameLoop.h>
+
+namespace CaveGame
+{
+
+bool CaveGameLoop::on_game_start()
+{
+    return true;
+}
+
+void CaveGameLoop::on_game_end()
+{}
+
+void CaveGameLoop::on_game_update(float delta_time)
+{}
+
+} // namespace CaveGame

--- a/Source/CaveGameLoop.h
+++ b/Source/CaveGameLoop.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Catalin Ionescu 2024. All rights reserved.
+ * Copyright (c) Robert Bengulescu 2024. All rights reserved.
+ * Copyright (c) Traian Avram 2024. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#pragma once
+
+#include <Engine/GameLoop.h>
+
+namespace CaveGame
+{
+
+class CaveGameLoop : public GameLoop
+{
+public:
+    virtual bool on_game_start() override;
+    virtual void on_game_update(float delta_time) override;
+    virtual void on_game_end() override;
+};
+
+} // namespace CaveGame

--- a/Source/EntryPoint.cpp
+++ b/Source/EntryPoint.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <CaveGameLoop.h>
 #include <Engine/Engine.h>
 
 namespace CaveGame
@@ -25,9 +26,9 @@ static int cave_game_main()
         // Engine initialize failed. Aborting.
         return 1;
     }
-    
+
     // Run game.
-    engine->run();
+    engine->run<CaveGameLoop>();
 
     engine->shutdown();
     delete engine;


### PR DESCRIPTION
At least in the beginning, I want the engine to be quite minimalistic. The game loop is created and managed by the engine, but the functions implementions (`on_update`, `on_start`, `on_end`) are entirely defined by the game.

Note that in the future we will most likely use the `Scene` architecture (a `Scene` is a collection of entities or actors that are updated and managed by the engine), which would require to rework this game loop interface. But the approach we are currently taking will result in much faster iteration time and is also easier to understand.